### PR TITLE
remove request warning

### DIFF
--- a/src/EurekaClient.js
+++ b/src/EurekaClient.js
@@ -203,18 +203,12 @@ export default class Eureka extends EventEmitter {
   */
   register(callback = noop) {
     this.config.instance.status = 'UP';
-    const connectionTimeout = setTimeout(() => {
-      this.logger.warn('It looks like it\'s taking a while to register with ' +
-        'Eureka. This usually means there is an issue connecting to the host ' +
-        'specified. Start application with NODE_DEBUG=request for more logging.');
-    }, 10000);
     this.eurekaRequest({
       method: 'POST',
       uri: this.config.instance.app,
       json: true,
       body: { instance: this.config.instance },
     }, (error, response, body) => {
-      clearTimeout(connectionTimeout);
       if (!error && response.statusCode === 204) {
         this.logger.info(
           'registered with eureka: ',


### PR DESCRIPTION
This message is often seen when nothing is wrong at all, yet enabling `NODE_DEBUG: request` is a terrible idea for all but the most extreme cases, as it can print things you would not want to share with others.